### PR TITLE
Fix Kent with Flask 2.1.0+ (#23)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,16 @@ def get_file(fn):
         return fp.read()
 
 
-INSTALL_REQUIRES = ["flask<3"]
+INSTALL_REQUIRES = ["flask>=2.1.0,<3"]
 EXTRAS_REQUIRE = {
     "dev": [
-        "black==21.12b0",
+        "black==22.3.0",
         "flake8==4.0.1",
-        "pytest==6.2.5",
-        "sentry-sdk==1.5.3",
+        "pytest==7.1.1",
+        "sentry-sdk==1.5.8",
         "tox==3.24.5",
         "tox-gh-actions==2.9.1",
-        "twine==3.7.1",
+        "twine==3.8.0",
     ]
 }
 

--- a/src/kent/cli_server.py
+++ b/src/kent/cli_server.py
@@ -5,11 +5,10 @@
 import os
 import socket
 
-from flask.cli import cli as flask_cli
-from werkzeug import serving
-
 os.environ["FLASK_APP"] = "kent.app"
-os.environ["WERKZEUG_RUN_MAIN"] = "true"
+
+from flask.cli import main as flask_main  # noqa
+from werkzeug import serving  # noqa
 
 
 def mock_get_interface_ip(family):
@@ -27,4 +26,4 @@ serving.get_interface_ip = mock_get_interface_ip
 
 
 def main():
-    flask_cli.main()
+    flask_main()


### PR DESCRIPTION
This fixes Kent to work with Flask 2.1.0. Something about the way we were (ab)using Flask's cli was triggering an error in werkzeug. This fixes it.

Fixes #23.