### PR TITLE
Add summary to kent error list (#27)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ test:  ## Run tests and static typechecking
 
 .PHONY: lint
 lint:  ## Lint and black reformat files
-	black --target-version=py37 --line-length=88 src tests setup.py
-	flake8 src
+	black --target-version=py37 --line-length=88 bin src tests setup.py
+	flake8 bin src tests setup.py
 
 .PHONY: clean
 clean:  ## Clean build artifacts

--- a/bin/kent_submit.py
+++ b/bin/kent_submit.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Usage: python bin/kent_submit.py [FILE]
+
+import argparse
+import json
+
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser(description="submit sentry events to kent")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", default="8000")
+    parser.add_argument("file", nargs="+", help="entry files to submit")
+
+    args = parser.parse_args()
+
+    for fn in args.file:
+        with open(fn, "r") as fp:
+            data = json.load(fp)
+
+            if "payload" in data:
+                data = data["payload"]
+
+            print(f"Submitting {fn}...")
+            resp = requests.post(
+                f"http://{args.host}:{args.port}/api/0/store/", json=data
+            )
+            resp.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ EXTRAS_REQUIRE = {
         "black==22.3.0",
         "flake8==4.0.1",
         "pytest==7.1.1",
+        "requests",
         "sentry-sdk==1.5.8",
         "tox==3.24.5",
         "tox-gh-actions==2.9.1",

--- a/src/kent/app.py
+++ b/src/kent/app.py
@@ -11,9 +11,9 @@ from typing import Union
 import uuid
 import zlib
 
-from kent import __version__
-
 from flask import Flask, request, render_template
+
+from kent import __version__
 
 
 dictConfig(
@@ -42,8 +42,22 @@ class Error:
     # sentry-sdk
     payload: Union[dict, bytes]
 
-    def get_timestamp(self):
+    @property
+    def summary(self):
+        if not self.payload or not isinstance(self.payload, dict):
+            return "no summary"
+
+        exceptions = self.payload.get("exception", {}).get("values", [])
+        if exceptions:
+            first = exceptions[0]
+            return f"{first['type']}: {first['value']}"
+
+        return "no summary"
+
+    @property
+    def timestamp(self):
         if self.payload and isinstance(self.payload, dict):
+            # NOTE(willkg): timestamp is a string
             return self.payload.get("timestamp", "none")
 
         return "none"

--- a/src/kent/static/style.css
+++ b/src/kent/static/style.css
@@ -2,6 +2,10 @@
     white-space: nowrap;
 }
 
-td, th {
+th, td {
     vertical-align: top;
+}
+
+table.summary th, table.summary td {
+    font-size: 0.8em;
 }

--- a/src/kent/templates/index.html
+++ b/src/kent/templates/index.html
@@ -33,18 +33,18 @@
           <a href="#" onClick ="javascript:flush()">[Flush]</a>
         </p>
         {% if errors %}
-          <table>
+          <table class="summary">
             <thead>
               <th>timestamp</th>
-              <th>project id</th>
-              <th>id</th>
+              <th>project: event id</th>
+              <th>summary</th>
             </thead>
             <tbody>
               {% for error in errors %}
                 <tr>
-                  <td>{{ error.get_timestamp() }}</td>
-                  <td>{{ error.project_id }}</td>
-                  <td><a href="/api/error/{{ error.error_id }}">{{ error.error_id }}</a></td>
+                  <td>{{ error.timestamp }}</td>
+                  <td class="nowrap"><a href="/api/error/{{ error.error_id }}">{{ error.project_id }}: {{ error.error_id }}</a></td>
+                  <td>{{ error.summary }}</td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,7 @@
 import pytest
 import uuid
 
-from kent.app import create_app
+from kent.app import create_app, Error
 
 
 @pytest.fixture
@@ -10,6 +10,25 @@ def client():
 
     with app.test_client() as client:
         yield client
+
+
+class TestError:
+    @pytest.mark.parametrize(
+        "payload, expected", [
+            # Empty error payload
+            ({}, "no summary"),
+            # Error payload for an exception
+            (
+                {"exception": {"values": [{"type": "Exception", "value": "Intentional exception"}]}},
+                "Exception: Intentional exception"
+            ),
+        ]
+    )
+    def test_summary(self, payload, expected):
+        error = Error(
+            project_id="0", error_id="9884b351-1e8f-4a28-8a9a-fc0033467e4e", payload=payload
+        )
+        assert error.summary == expected
 
 
 def test_index_view(client):

--- a/tox.ini
+++ b/tox.ini
@@ -18,5 +18,5 @@ commands =
 basepython = python3.7
 changedir = {toxinidir}
 commands =
-    black --check --target-version=py37 --line-length=88 src tests
-    flake8 src tests
+    black --check --target-version=py37 --line-length=88 bin src tests setup.py
+    flake8 bin src tests setup.py


### PR DESCRIPTION
This adds a summary column to the error list table. It adds some helper
CSS for that.

It also adds a kent_submit.py script to make it easier to test kent in
local dev environment.

It also fixes the linting rule in tox and Makefile.

Fixes #27.