### PR TITLE
Added Github workflow to automatically create docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: build
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: login to docker hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: build, tag and push docker image to docker hub
+        run: |
+          BUILD=${GITHUB_REF#refs/*/}
+
+          docker build -t willkg/kent:$BUILD .
+          docker push willkg/kent:$BUILD
+
+          docker tag willkg/kent:$BUILD willkg/kent:latest
+          docker push willkg/kent:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,8 @@ WORKDIR /app/
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
-# NOTE(willkg): This installs Kent from main tip. If you're using Kent for
-# realzies, you probably don't want to do this because Kent could change and
-# break all your stuff. Pick a specific commit.
-RUN pip install -U 'pip>=8' && \
-    pip install --no-cache-dir 'https://github.com/willkg/kent/archive/refs/heads/main.zip'
+COPY . .
+RUN pip install -U 'pip>=' .
 
 USER guest
 


### PR DESCRIPTION
This will automatically build and push a docker image (using the dockerfile in the root of the repo) each time a new tag is pushed to this repo. You'll just need to register for an account on docker hub, and then add your username and API token as secrets to your repo for this to work. I've set this up under the assumption that your username will also be willkg on docker hub.

This also updates the dockerfile to do the pip install from the repo's files directly - as this will only build on tags, the dockerfile's build will match that of the tag (instead of just downloading the latest main branch)
