### PR TITLE
Add loggingerror to testpost (#48)

### DIFF
--- a/src/kent/cli_testpost.py
+++ b/src/kent/cli_testpost.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+import logging
 from urllib.parse import urlparse
 import sys
 
@@ -28,11 +29,15 @@ def main():
         "kind",
         nargs="?",
         default="message",
-        help="What kind of thing to post. ['message', 'error', 'security']",
+        help=(
+            "What kind of thing to post. ['message', 'error', 'loggingerror', "
+            + "'security']"
+        ),
     )
 
     args = parser.parse_args()
 
+    logging.basicConfig(level=logging.ERROR)
     init(args.dsn)
 
     if args.kind == "message":
@@ -41,9 +46,16 @@ def main():
 
     elif args.kind == "error":
         try:
-            raise Exception
+            raise Exception("intentional exception")
         except Exception as exc:
             capture_exception(exc)
+        print(f"Error posted to: {args.dsn}")
+
+    elif args.kind == "loggingerror":
+        try:
+            raise Exception("intentional exception")
+        except Exception:
+            logging.exception("intentional exception")
         print(f"Error posted to: {args.dsn}")
 
     elif args.kind == "security":


### PR DESCRIPTION
This adds loggingerror to testpost which allowed me to go through sentry-sdk versions looking for one where the error handler or logging handler producing payloads to see how Kent handles them.