### PR TITLE
Fix banner for 0.0.0.0 and ipv6 addresses

### DIFF
--- a/src/kent/cli_server.py
+++ b/src/kent/cli_server.py
@@ -7,8 +7,7 @@ import sys
 
 import kent.app
 
-from flask import cli  # noqa
-from werkzeug import serving  # noqa
+from flask import cli
 
 
 os.environ["FLASK_APP"] = "kent.app"
@@ -27,6 +26,16 @@ def maybe_show_banner():
         opts, _, _ = parser.parse_args(args[1:])
         port = opts.get("port", 5000)
         host = opts.get("host", "127.0.0.1")
+
+        # Convert any adapter to localhost
+        if host == "0.0.0.0":
+            host = "localhost"
+        elif host == "::":
+            host = "::1"
+
+        if ":" in host:
+            host = f"[{host}]"
+
         kent.app.BANNER = f"Listening on http://{host}:{port}/"
 
 


### PR DESCRIPTION
After this, the following should all produce "Listening on" messages that work when Kent is running locally and in a Docker container:

* `kent-server run` -- defaults to `127.0.0.1:5000`
* `kent-server run --host=0.0.0.0`
* `kent-server run --host=::1`
* `kent-server run --host=::`