### PR TITLE
add support for envelope api (#42)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,40 @@
 HISTORY
 =======
 
+2.0.0 (In development)
+======================
+
+Backwards incompatible changes:
+
+* Changed ``/api/errorlist/`` to ``/api/eventlist/`` and changed response
+  to a list of JSON objects with "error_id", "project_id", and "summary"
+  keys.
+
+  Example::
+
+      curl http://localhost:5000/api/eventlist/
+      {"events":[{"event_id":"1b1211bb-a113-480c-a3c9-0c7e7aea5e27","project
+      _id":1,"summary":"test error capture"}]}
+
+* Changed ``/api/error/ERROR_ID/`` to ``/api/event/EVENT_ID/`` and changed
+  response so that the payload is now a JSON object with "envelope_header",
+  "header", and "body" keys.
+
+  If the event was captured using the ``store`` API, then "envelope_header" and
+  "header" will be nulls and "body" will contain the payload.
+
+  If the event was captured using the ``envelope`` API, then "envelope_header"
+  will be the payload envelope header, "header" will be the item header, and
+  "body" will be the item.
+
+Changes:
+
+* Feature: Support ``envelope`` API. (#42)
+* Maintenance: Update to Flask 3. (#73)
+
+Kent quietly stares off into the distance.
+
+
 1.2.0 (January 31st, 2024)
 ==========================
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Goals of Kent:
 
 1. make it possible to debug ``before_send`` and ``before_breadcrumb``
    sanitization code when using sentry-sdk
-2. make it possible to debug other sentry error submission payload issues
+2. make it possible to debug other sentry event submission payload issues
 3. make it possible to write integration tests against a fake sentry instance
 
 
@@ -85,7 +85,7 @@ Things to know about Kent
 =========================
 
 Kent is the fakest of fake Sentry servers. You can set up a Sentry DSN to point
-to Kent and have your application send errors to it.
+to Kent and have your application send events to it.
 
 Kent is for testing sentry-sdk things. Kent is not for testing Relay.
 
@@ -94,28 +94,28 @@ Kent is a refined fake Sentry service and doesn't like fast food.
 Kent will keep track of the last 100 payloads it received in memory. Nothing is
 persisted to disk.
 
-You can access the list of errors and error data with your web browser by going
+You can access the list of events and event data with your web browser by going
 to Kent's index page.
 
 You can also access it with the API. This is most useful for integration tests
-that want to assert things about errors.
+that want to assert things about events.
 
-``GET /api/errorlist/``
-    List of all errors in memory with a unique error id.
+``GET /api/eventlist/``
+    List of all events in memory with a unique event id.
 
-``GET /api/error/ERRORID``
-    Retrieve the payload for a specific error by id.
+``GET /api/event/EVENT_ID``
+    Retrieve the payload for a specific event by id.
 
 ``POST /api/flush/``
-    Flushes the error manager of all errors.
+    Flushes the event manager of all events.
 
-You can use multiple project ids. Kent will keep the errors separate.
+You can use multiple project ids. Kent will keep the events separate.
 
 If you run ``kent-server run`` with the defaults, your DSN is::
 
     http://public@localhost:5000/1    for project id 1
     http://public@localhost:5000/2    for project id 2
-    ...
+    etc.
 
 
 Kent definitely works with:

--- a/src/kent/cli_testpost.py
+++ b/src/kent/cli_testpost.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+from importlib.metadata import version as metadata_version
 import logging
 from urllib.parse import urlparse
 import sys
@@ -40,6 +41,8 @@ def main():
     logging.basicConfig(level=logging.ERROR)
     init(args.dsn)
 
+    print(f"DSN: {args.dsn}")
+    print(f"Sentry-sdk version: {metadata_version('sentry_sdk')}")
     if args.kind == "message":
         capture_message("test error capture")
         print(f"Message posted to: {args.dsn}")
@@ -69,6 +72,7 @@ def main():
 
         if args.kind == "security_csp_new":
             # Newer browsers send this structure
+            # From: https://w3c.github.io/reporting/#sample-reports
             data = [
                 {
                     "age": 0,

--- a/src/kent/static/style.css
+++ b/src/kent/static/style.css
@@ -5,3 +5,10 @@
 th, td {
     vertical-align: top;
 }
+
+pre code {
+    text-wrap: wrap;
+    text-wrap-mode: wrap;
+    overflow: scroll;
+    word-break: break-all;
+}

--- a/src/kent/templates/index.html
+++ b/src/kent/templates/index.html
@@ -27,12 +27,12 @@
           <h2>A fake Sentry server for debugging and integration tests</h2>
         </hgroup>
 
-        <h2>Errors</h2>
+        <h2>Events</h2>
         <p>
-          There are {{ errors|count }} errors in memory.
+          There are {{ events|count }} events in memory.
           <a href="#" onClick ="javascript:flush()">[Flush]</a>
         </p>
-        {% if errors %}
+        {% if events %}
           <table class="summary" role="grid">
             <thead>
               <tr>
@@ -42,11 +42,11 @@
               </tr>
             </thead>
             <tbody>
-              {% for error in errors %}
+              {% for event in events %}
                 <tr>
-                  <td scope="row"><small>{{ error.timestamp }}</small></td>
-                  <td class="nowrap"><small><a href="/api/error/{{ error.error_id }}">{{ error.project_id }}: {{ error.error_id }}</a><small></td>
-                  <td><small>{{ error.summary }}</small></td>
+                  <td scope="row"><small>{{ event.timestamp }}</small></td>
+                  <td class="nowrap"><small><a href="/api/event/{{ event.event_id }}">{{ event.project_id }}: {{ event.event_id }}</a><small></td>
+                  <td><small>{{ event.summary }}</small></td>
                 </tr>
               {% endfor %}
             </tbody>
@@ -65,65 +65,65 @@
               <p><code>GET {{ dsn }}</code></p>
               <p>Returns no payload.</p>
               <p>
-                If you're running this in a Docker container and the
-                service you want sending errors to Fake Sentry is in another
-                Docker container, then you will need to use the appropriate
-                host for the service.
+                If you're running this in a Docker container and the service
+                you want sending errors to Fake Sentry is in another Docker
+                container, then you will need to use the appropriate host for
+                the service.
               </p>
             </td>
           </tr>
           <tr>
-            <td class="nowrap">Error list</td>
+            <td class="nowrap">Event list</td>
             <td>
-              <p><code>GET {{ host }}/api/errorlist/</code></p>
+              <p><code>GET {{ host }}/api/eventlist/</code></p>
               <p>Returns JSON payload.</p>
               <dl>
-                <dt><code>errors</code></dt>
-                <dd>List of error ids as strings.</dd>
+                <dt><code>events</code></dt>
+                <dd>List of event structures containing the event id, project id, and summary.</dd>
               </dl>
               <p>Example:</p>
-<pre><code>{
-  "errors": [
-    "f2edba96-0433-47e0-af86-ecfbbb16a544",
-    "1a45b81f-5960-4174-9945-7fe9a8285d90
-  ]
-}</code></pre>
+<pre><code>curl http://localhost:5000/api/eventlist/
+{"events":[{"event_id":"1b1211bb-a113-480c-a3c9-0c7e7aea5e27","project_id":1,"summary":"test error capture"}]}
+</code></pre>
             </td>
           </tr>
           <tr>
-            <td class="nowrap">Error</td>
+            <td class="nowrap">Event</td>
             <td>
-              <p><code>GET {{ host }}/api/error/&lt;ERRORID&gt;</code></p>
+              <p><code>GET {{ host }}/api/event/&lt;EVENT_ID&gt;</code></p>
               <p>Returns JSON payload.</p>
               <dl>
                 <dt><code>project_id</code></dt>
                 <dd>Project id as an int</dd>
-                <dt><code>error_id</code></dt>
-                <dd>Error id as a string</dd>
+                <dt><code>event_id</code></dt>
+                <dd>Event id as a string</dd>
                 <dt><code>payload</code></dt>
-                <dd>Error payload sent by the sentry-sdk</dd>
+                <dd>Event payload sent by the sentry-sdk</dd>
               </dl>
               <p>Contrived example:</p>
-<pre><code>{
-  "project_id": 1,
-  "error_id": "f2edba96-0433-47e0-af86-ecfbbb16a544",
-  "payload": {
-    whatever sentry-sdk sent here
-  }
-}</code></pre>
+<pre><code>curl http://localhost:5000/api/event/1f54272a-8cd6-45c9-8cf9-a06d844ec293
+{"event_id":"1f54272a-8cd6-45c9-8cf9-a06d844ec293","payload":{"body":{"breadcrumbs":{"values":[]},"contexts":{"runtime":{"build":"3.10.14 (main, May  6 2024, 10:26:19) [GCC 13.2.0]","name":"CPython","version":"3.10.14"},"trace":{"parent_span_id":null,"span_id":"bb4b07d835a10c3e","trace_id":"99ec1fa063a141e0bb514fd9bbb57c54"}},"environment":"production","event_id":"753b3e32cd2c471c9480444e7fd12897","extra":{"sys.argv":["/home/willkg/venvs/kent/bin/kent-testpost","message"]},"level":"info","message":"test error capture","modules":{"blinker":"1.8.2","certifi":"2024.2.2","charset-normalizer":"3.3.2","click":"8.1.7","flask":"3.0.3","idna":"3.7","itsdangerous":"2.2.0","jinja2":"3.1.4","kent":"1.2.0","markupsafe":"2.1.5","pip":"24.0","requests":"2.31.0","sentry-sdk":"1.45.0","setuptools":"69.5.1","urllib3":"2.2.1","werkzeug":"3.0.3","wheel":"0.43.0"},"platform":"python","release":"96ed17acbc96f2af558a2989025b5acaa994c511","sdk":{"integrations":["argv","atexit","dedupe","excepthook","flask","logging","modules","stdlib","threading"],"name":"sentry.python.flask","packages":[{"name":"pypi:sentry-sdk","version":"1.45.0"}],"version":"1.45.0"},"server_name":"saturn7","timestamp":"2024-05-19T01:02:09.184703Z","transaction_info":{}},"envelope_header":null,"header":null},"project_id":1}
+</code></pre>
+              <p>
+                The payload data depends on which version of sentry-sdk
+                you're using and how it submitted the data.
+              </p>
             </td>
           </tr>
           <tr>
-            <td class="nowrap">Flush errors</td>
+            <td class="nowrap">Flush events</td>
             <td>
               <p><code>POST {{ host }}/api/flush/</code></p>
               <p>Returns JSON payload.</p>
+              <p>HTTP 200</p>
               <dl>
                   <dt><code>success</code></dt>
                   <dd><i>true</i> if successful</dd>
               </dl>
               <p>Example:</p>
-<pre><code>{"success": true}</code></pre>
+<pre><code>curl -X POST http://localhost:5000/api/flush/
+{"success": true}
+</code></pre>
           </tr>
         </table>
       </main>

--- a/src/kent/utils.py
+++ b/src/kent/utils.py
@@ -1,0 +1,99 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from dataclasses import dataclass
+import logging
+import json
+from typing import Union
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Item:
+    envelope_header: dict
+    header: dict
+    body: Union[dict, bytes]
+
+
+def get_newline_index(body, start_index, end_index):
+    end_index = body.find(b"\n", start_index)
+    if end_index == -1:
+        # If there are no more \n, then the end_index is the last index in the
+        # body
+        end_index = len(body)
+    else:
+        while body[end_index] == "\r":
+            end_index = body.find(b"\n", end_index + 1)
+    return end_index
+
+
+def parse_envelope(body):
+    """Parses an envelope payload into items
+
+    :arg body: the envelope payload body
+
+    :returns: generator of items
+
+    """
+
+    body_length = len(body)
+    start_index = end_index = 0
+    read_length = -1
+
+    envelope_header = None
+
+    # Absorb envelope
+    # See: https://develop.sentry.dev/sdk/envelopes/
+    while end_index < body_length:
+        start_index = end_index
+        end_index = get_newline_index(body, start_index, end_index)
+
+        if envelope_header is None:
+            envelope_header = json.loads(body[start_index:end_index])
+            end_index += 1
+            continue
+
+        json_part = body[start_index:end_index]
+
+        try:
+            part = json.loads(json_part)
+        except Exception:
+            LOGGER.exception("exception when JSON-decoding body.")
+            LOGGER.error("%s", json_part)
+            raise
+
+        if "type" in part:
+            # Advance past the \n
+            end_index += 1
+
+            start_index = end_index
+            read_length = part.get("length", -1)
+            if read_length != -1:
+                # NOTE(willkg): This will include the newline separater at the end
+                end_index = end_index + read_length
+            else:
+                end_index = get_newline_index(body, start_index, end_index)
+
+            # NOTE(willkg): This drops the newline separator because it's not
+            # part of the Item body
+            item_body = body[start_index:end_index]
+
+            if part.get("type") == "attachment":
+                yield Item(
+                    envelope_header=envelope_header,
+                    header=part,
+                    body=item_body,
+                )
+
+            else:
+                item_body_data = json.loads(item_body)
+                yield Item(
+                    envelope_header=envelope_header, header=part, body=item_body_data
+                )
+
+            # Advance past the \n
+            end_index += 1
+            continue

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,7 @@
 import pytest
 import uuid
 
-from kent.app import create_app, Error
+from kent.app import create_app, Event
 
 
 @pytest.fixture
@@ -12,13 +12,13 @@ def client():
         yield client
 
 
-class TestError:
+class TestEvent:
     @pytest.mark.parametrize(
         "payload, expected",
         [
-            # Empty error payload
+            # Empty event payload
             ({}, "no summary"),
-            # Error payload for an exception
+            # Event payload for an exception
             (
                 {
                     "exception": {
@@ -39,12 +39,12 @@ class TestError:
         ],
     )
     def test_summary(self, payload, expected):
-        error = Error(
+        event = Event(
             project_id="0",
-            error_id="9884b351-1e8f-4a28-8a9a-fc0033467e4e",
+            event_id="9884b351-1e8f-4a28-8a9a-fc0033467e4e",
             payload=payload,
         )
-        assert error.summary == expected
+        assert event.summary == expected
 
 
 def test_index_view(client):
@@ -68,44 +68,44 @@ def test_api_flush_view(client):
     assert resp.json == {"success": True}
 
 
-class TestAPIErrorListView:
-    def test_empty_errorlist(self, client):
-        resp = client.get("/api/errorlist/")
-        assert resp.json == {"errors": []}
+class TestAPIEventListView:
+    def test_empty_eventlist(self, client):
+        resp = client.get("/api/eventlist/")
+        assert resp.json == {"events": []}
 
-    def test_nonempty_errorlist(self, client):
-        # Store an error
+    def test_nonempty_eventlist(self, client):
+        # Store an event
         resp = client.post("/api/1/store/", json={"id": "xyz"})
         assert resp.status_code == 200
 
-        resp = client.get("/api/errorlist/")
+        resp = client.get("/api/eventlist/")
         assert len(resp.json) == 1
 
 
-class TestAPIErrorView:
+class TestAPIEventView:
     def test_404(self, client):
-        error_id = str(uuid.uuid4())
-        resp = client.get(f"/api/error/{error_id}")
+        event_id = str(uuid.uuid4())
+        resp = client.get(f"/api/event/{event_id}")
         assert resp.status_code == 404
-        assert resp.json == {"error": f"Error {error_id} not found"}
+        assert resp.json == {"error": f"Event {event_id} not found"}
 
-    def test_error_exists(self, client):
-        error_payload = {"id": "new error"}
+    def test_event_exists(self, client):
+        event_payload = {"id": "new event"}
 
-        # Store an error
-        resp = client.post("/api/1/store/", json=error_payload)
+        # Store an event
+        resp = client.post("/api/1/store/", json=event_payload)
         assert resp.status_code == 200
 
-        # Get all the errors
-        resp = client.get("/api/errorlist/")
+        # Get all the events
+        resp = client.get("/api/eventlist/")
         assert resp.status_code == 200
-        error_id = resp.json["errors"][0]
+        event_id = resp.json["events"][0]
 
-        # Get the error by error_id
-        resp = client.get(f"/api/error/{error_id}")
+        # Get the event by event_id
+        resp = client.get(f"/api/event/{event_id}")
         assert resp.status_code == 200
         assert resp.json == {
             "project_id": 1,
-            "error_id": error_id,
-            "payload": error_payload,
+            "event_id": event_id,
+            "payload": event_payload,
         }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
 import uuid
 
@@ -42,7 +46,7 @@ class TestEvent:
         event = Event(
             project_id="0",
             event_id="9884b351-1e8f-4a28-8a9a-fc0033467e4e",
-            payload=payload,
+            body=payload,
         )
         assert event.summary == expected
 
@@ -52,13 +56,218 @@ def test_index_view(client):
     assert b"Kent" in resp.data
 
 
+# From "kent-testpost" message with Python sentry-sdk 1.45.0
+SENTRY_SDK_1_45_0_ERROR = {
+    "breadcrumbs": {"values": []},
+    "contexts": {
+        "runtime": {
+            "build": "3.10.14 (main, May  6 2024, 10:26:19) [GCC 13.2.0]",
+            "name": "CPython",
+            "version": "3.10.14",
+        },
+        "trace": {
+            "parent_span_id": None,
+            "span_id": "93e11289cc659ab8",
+            "trace_id": "b7c12e7267ff4886a935914889833319",
+        },
+    },
+    "environment": "production",
+    "event_id": "9ae282ae03b6476ebeb1392a151edf55",
+    "extra": {"sys.argv": ["/home/willkg/venvs/kent/bin/kent-testpost", "message"]},
+    "level": "info",
+    "message": "test error capture",
+    "modules": {
+        "blinker": "1.8.2",
+        "certifi": "2024.2.2",
+        "charset-normalizer": "3.3.2",
+        "click": "8.1.7",
+        "flask": "3.0.3",
+        "idna": "3.7",
+        "itsdangerous": "2.2.0",
+        "jinja2": "3.1.4",
+        "kent": "1.2.0",
+        "markupsafe": "2.1.5",
+        "pip": "24.0",
+        "requests": "2.31.0",
+        "sentry-sdk": "1.45.0",
+        "setuptools": "69.5.1",
+        "urllib3": "2.2.1",
+        "werkzeug": "3.0.3",
+        "wheel": "0.43.0",
+    },
+    "platform": "python",
+    "release": "2667f04c7246db93ecbc175cf7a2534ad412154e",
+    "sdk": {
+        "integrations": [
+            "argv",
+            "atexit",
+            "dedupe",
+            "excepthook",
+            "flask",
+            "logging",
+            "modules",
+            "stdlib",
+            "threading",
+        ],
+        "name": "sentry.python.flask",
+        "packages": [{"name": "pypi:sentry-sdk", "version": "1.45.0"}],
+        "version": "1.45.0",
+    },
+    "server_name": "saturn7",
+    "timestamp": "2024-05-19T02:22:32.086845Z",
+    "transaction_info": {},
+}
+
+
 def test_store_view(client):
-    resp = client.post("/api/1/store/", json={"id": "xyz"})
+    resp = client.post(
+        "/api/1/store/",
+        json=SENTRY_SDK_1_45_0_ERROR,
+    )
+
     assert resp.status_code == 200
 
 
+def test_envelope_view(client):
+    resp = client.post(
+        "/api/1/envelope/",
+        content_type="application/octet-stream",
+        # From "kent-testpost message" with Python sentry-sdk 2.2.0
+        data=(
+            b'{"event_id":"b5a2369b82c7421eb5c118a3151da03e","sent_at":"2024-05-19T03:13:43.016351Z","trace":{"trace_id":"e2a6aebaa043485e93cb5c8df6fbc230","environment":"production","release":"2667f04c7246db93ecbc175cf7a2534ad412154e","public_key":"public"}}\n{"type":"event","content_type":"application/json","length":1164}\n{"message":"test error capture","level":"info","event_id":"b5a2369b82c7421eb5c118a3151da03e","timestamp":"2024-05-19T03:13:43.015857Z","contexts":{"trace":{"trace_id":"e2a6aebaa043485e93cb5c8df6fbc230","span_id":"aa35c2671f716d4d","parent_span_id":null},"runtime":{"name":"CPython","version":"3.10.14","build":"3.10.14 (main, May  6 2024, 10:26:19) [GCC 13.2.0]"}},"transaction_info":{},"breadcrumbs":{"values":[]},"extra":{"sys.argv":["/home/willkg/venvs/kent/bin/kent-testpost","message"]},"modules":{"pip":"24.0","flask":"3.0.3","sentry-sdk":"2.2.0","wheel":"0.43.0","idna":"3.7","setuptools":"69.5.1","click":"8.1.7","blinker":"1.8.2","urllib3":"2.2.1","kent":"1.2.0","markupsafe":"2.1.5","werkzeug":"3.0.3","charset-normalizer":"3.3.2","itsdangerous":"2.2.0","requests":"2.31.0","jinja2":"3.1.4","certifi":"2024.2.2"},"release":"2667f04c7246db93ecbc175cf7a2534ad412154e","environment":"production","server_name":"saturn7","sdk":{"name":"sentry.python.flask","version":"2.2.0","packages":[{"name":"pypi:sentry-sdk","version":"2.2.0"}],"integrations":["argv","atexit","dedupe","excepthook","flask","logging","modules","stdlib","threading"]},"platform":"python"}\n'
+        ),
+    )
+    assert resp.status_code == 200
+
+    # Get all the events
+    resp = client.get("/api/eventlist/")
+    assert resp.status_code == 200
+    event_id = resp.json["events"][0]["event_id"]
+
+    # Get the event by event_id
+    resp = client.get(f"/api/event/{event_id}")
+    assert resp.status_code == 200
+    assert resp.json == {
+        "event_id": event_id,
+        "payload": {
+            "body": {
+                "breadcrumbs": {
+                    "values": [],
+                },
+                "contexts": {
+                    "runtime": {
+                        "build": "3.10.14 (main, May  6 2024, 10:26:19) [GCC 13.2.0]",
+                        "name": "CPython",
+                        "version": "3.10.14",
+                    },
+                    "trace": {
+                        "parent_span_id": None,
+                        "span_id": "aa35c2671f716d4d",
+                        "trace_id": "e2a6aebaa043485e93cb5c8df6fbc230",
+                    },
+                },
+                "environment": "production",
+                "event_id": "b5a2369b82c7421eb5c118a3151da03e",
+                "extra": {
+                    "sys.argv": [
+                        "/home/willkg/venvs/kent/bin/kent-testpost",
+                        "message",
+                    ],
+                },
+                "level": "info",
+                "message": "test error capture",
+                "modules": {
+                    "blinker": "1.8.2",
+                    "certifi": "2024.2.2",
+                    "charset-normalizer": "3.3.2",
+                    "click": "8.1.7",
+                    "flask": "3.0.3",
+                    "idna": "3.7",
+                    "itsdangerous": "2.2.0",
+                    "jinja2": "3.1.4",
+                    "kent": "1.2.0",
+                    "markupsafe": "2.1.5",
+                    "pip": "24.0",
+                    "requests": "2.31.0",
+                    "sentry-sdk": "2.2.0",
+                    "setuptools": "69.5.1",
+                    "urllib3": "2.2.1",
+                    "werkzeug": "3.0.3",
+                    "wheel": "0.43.0",
+                },
+                "platform": "python",
+                "release": "2667f04c7246db93ecbc175cf7a2534ad412154e",
+                "sdk": {
+                    "integrations": [
+                        "argv",
+                        "atexit",
+                        "dedupe",
+                        "excepthook",
+                        "flask",
+                        "logging",
+                        "modules",
+                        "stdlib",
+                        "threading",
+                    ],
+                    "name": "sentry.python.flask",
+                    "packages": [
+                        {
+                            "name": "pypi:sentry-sdk",
+                            "version": "2.2.0",
+                        },
+                    ],
+                    "version": "2.2.0",
+                },
+                "server_name": "saturn7",
+                "timestamp": "2024-05-19T03:13:43.015857Z",
+                "transaction_info": {},
+            },
+            "envelope_header": {
+                "event_id": "b5a2369b82c7421eb5c118a3151da03e",
+                "sent_at": "2024-05-19T03:13:43.016351Z",
+                "trace": {
+                    "environment": "production",
+                    "public_key": "public",
+                    "release": "2667f04c7246db93ecbc175cf7a2534ad412154e",
+                    "trace_id": "e2a6aebaa043485e93cb5c8df6fbc230",
+                },
+            },
+            "header": {
+                "content_type": "application/json",
+                "length": 1164,
+                "type": "event",
+            },
+        },
+        "project_id": 1,
+    }
+
+
+# From "kent-testpost security_csp_new"
+CSP_REPORT_NEW = [
+    {
+        "age": 0,
+        "body": {
+            "blockedURL": "https://maps.googleapis.com/maps/api/js",
+            "disposition": "enforce",
+            "documentURL": "https://test.example.com/",
+            "effectiveDirective": "script-src",
+            "originalPolicy": "default-src 'self'; img-src 'self'; script-src 'self'; form-action 'self'; frame-ancestors 'self'; report-to csp-endpoint; report-uri http://public@public@localhost:5000/api/1/security/",
+            "referrer": "",
+            "statusCode": 200,
+        },
+        "type": "csp-violation",
+        "url": "https://test.example.com/",
+        "user_agent": "Mozilla/5.0 (user agent)",
+    }
+]
+
+
 def test_security_view(client):
-    resp = client.post("/api/1/security/", json=[{"id": "xyz"}])
+    resp = client.post(
+        "/api/1/security/",
+        # From "kent-testpost security_csp_new"
+        json=CSP_REPORT_NEW,
+    )
     assert resp.status_code == 200
 
 
@@ -75,7 +284,12 @@ class TestAPIEventListView:
 
     def test_nonempty_eventlist(self, client):
         # Store an event
-        resp = client.post("/api/1/store/", json={"id": "xyz"})
+        resp = client.post(
+            "/api/1/store/",
+            # From "kent-testpost" message with Python sentry-sdk 1.45.0
+            json=SENTRY_SDK_1_45_0_ERROR,
+        )
+
         assert resp.status_code == 200
 
         resp = client.get("/api/eventlist/")
@@ -90,16 +304,14 @@ class TestAPIEventView:
         assert resp.json == {"error": f"Event {event_id} not found"}
 
     def test_event_exists(self, client):
-        event_payload = {"id": "new event"}
-
         # Store an event
-        resp = client.post("/api/1/store/", json=event_payload)
+        resp = client.post("/api/1/store/", json=SENTRY_SDK_1_45_0_ERROR)
         assert resp.status_code == 200
 
         # Get all the events
         resp = client.get("/api/eventlist/")
         assert resp.status_code == 200
-        event_id = resp.json["events"][0]
+        event_id = resp.json["events"][0]["event_id"]
 
         # Get the event by event_id
         resp = client.get(f"/api/event/{event_id}")
@@ -107,5 +319,9 @@ class TestAPIEventView:
         assert resp.json == {
             "project_id": 1,
             "event_id": event_id,
-            "payload": event_payload,
+            "payload": {
+                "envelope_header": None,
+                "header": None,
+                "body": SENTRY_SDK_1_45_0_ERROR,
+            },
         }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,222 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from kent.utils import Item, parse_envelope
+
+
+class Test_parse_envelope:
+    def test_2_items(self):
+        payload = (
+            b'{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}\n'
+            b'{"type":"attachment","length":10,"content_type":"text/plain","filename":"hello.txt"}\n'
+            b"\xef\xbb\xbfHello\r\n\n"
+            b'{"type":"event","length":41,"content_type":"application/json","filename":"application.log"}\n'
+            b'{"message":"hello world","level":"error"}\n'
+        )
+
+        items = list(parse_envelope(payload))
+
+        assert items == [
+            Item(
+                envelope_header={
+                    "dsn": "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42",
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "content_type": "text/plain",
+                    "filename": "hello.txt",
+                    "length": 10,
+                    "type": "attachment",
+                },
+                body=b"\xef\xbb\xbfHello\r\n",
+            ),
+            Item(
+                envelope_header={
+                    "dsn": "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42",
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "content_type": "application/json",
+                    "filename": "application.log",
+                    "length": 41,
+                    "type": "event",
+                },
+                body={
+                    "level": "error",
+                    "message": "hello world",
+                },
+            ),
+        ]
+
+    def test_2_items_missing_trailing_newline(self):
+        payload = (
+            b'{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc","dsn":"https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42"}\n'
+            b'{"type":"attachment","length":10,"content_type":"text/plain","filename":"hello.txt"}\n'
+            b"\xef\xbb\xbfHello\r\n\n"
+            b'{"type":"event","length":41,"content_type":"application/json","filename":"application.log"}\n'
+            b'{"message":"hello world","level":"error"}'
+        )
+
+        items = list(parse_envelope(payload))
+
+        assert items == [
+            Item(
+                envelope_header={
+                    "dsn": "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42",
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "content_type": "text/plain",
+                    "filename": "hello.txt",
+                    "length": 10,
+                    "type": "attachment",
+                },
+                body=b"\xef\xbb\xbfHello\r\n",
+            ),
+            Item(
+                envelope_header={
+                    "dsn": "https://e12d836b15bb49d7bbf99e64295d995b:@sentry.io/42",
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "content_type": "application/json",
+                    "filename": "application.log",
+                    "length": 41,
+                    "type": "event",
+                },
+                body={
+                    "level": "error",
+                    "message": "hello world",
+                },
+            ),
+        ]
+
+    def test_2_empty_attachments(self):
+        payload = (
+            b'{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"}\n'
+            b'{"type":"attachment","length":0}\n'
+            b"\n"
+            b'{"type":"attachment","length":0}\n'
+            b"\n"
+        )
+
+        items = list(parse_envelope(payload))
+
+        assert items == [
+            Item(
+                envelope_header={
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "length": 0,
+                    "type": "attachment",
+                },
+                body=b"",
+            ),
+            Item(
+                envelope_header={
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "length": 0,
+                    "type": "attachment",
+                },
+                body=b"",
+            ),
+        ]
+
+    def test_2_empty_attachments_newline_omitted(self):
+        payload = (
+            b'{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"}\n'
+            b'{"type":"attachment","length":0}\n'
+            b"\n"
+            b'{"type":"attachment","length":0}\n'
+        )
+        items = list(parse_envelope(payload))
+
+        assert items == [
+            Item(
+                envelope_header={
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "length": 0,
+                    "type": "attachment",
+                },
+                body=b"",
+            ),
+            Item(
+                envelope_header={
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "length": 0,
+                    "type": "attachment",
+                },
+                body=b"",
+            ),
+        ]
+
+    def test_item_with_implicit_length(self):
+        payload = (
+            b'{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"}\n'
+            b'{"type":"attachment"}\n'
+            b"helloworld\n"
+        )
+        items = list(parse_envelope(payload))
+
+        assert items == [
+            Item(
+                envelope_header={
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "type": "attachment",
+                },
+                body=b"helloworld",
+            ),
+        ]
+
+    def test_item_implicit_length_eof_terminator(self):
+        payload = (
+            b'{"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"}\n'
+            b'{"type":"attachment"}\n'
+            b"helloworld"
+        )
+        items = list(parse_envelope(payload))
+
+        assert items == [
+            Item(
+                envelope_header={
+                    "event_id": "9ec79c33ec9942ab8353589fcb2e04dc",
+                },
+                header={
+                    "type": "attachment",
+                },
+                body=b"helloworld",
+            ),
+        ]
+
+    def test_empty_envelope_implicit_length_eof(self):
+        payload = (
+            b"{}\n"
+            b'{"type":"session"}\n'
+            b'{"started": "2020-02-07T14:16:00Z","attrs":{"release":"sentry-test@1.0.0"}}'
+        )
+        items = list(parse_envelope(payload))
+
+        assert items == [
+            Item(
+                envelope_header={},
+                header={
+                    "type": "session",
+                },
+                body={
+                    "attrs": {
+                        "release": "sentry-test@1.0.0",
+                    },
+                    "started": "2020-02-07T14:16:00Z",
+                },
+            ),
+        ]


### PR DESCRIPTION
This generalizes "error" to "event" which changed a lot of internal structure and also introduced two backwards-incompatible changes to the API:

1. `/api/errorlist/` becomes `/api/eventlist/` and the response is now a list of `{"event_id", "project_id", "summary"}` JSON objects
2. `/api/error/ERROR_ID/` becomes `/api/event/EVENT_ID/` and the response is still a `{"event_id", "project_id", "body"}` JSON object, but `"body"` is now a JSON object with `{"envelope_header", "header", body"}` keys.

All of that let us build out support for the `envelope` API: https://develop.sentry.dev/sdk/envelopes/

This allows Kent to work with Python sentry-sdk <= 1.45.0 as well as Python sentry-sdk >= 2.0.0 as well as other sentry-sdk clients.

Fixes #42 