### PR TITLE
Fix summary and summary logging (#91)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,9 @@ Changes:
 
 * Add support for Python 3.13. (#87)
 
+* Fix summaries for all the different types of things Kent handles. This also
+  reworks how CSP reports are handled. (#91)
+
 
 2.0.0 (May 19th, 2024)
 ======================

--- a/src/kent/cli_server.py
+++ b/src/kent/cli_server.py
@@ -20,7 +20,10 @@ cli.show_server_banner = lambda *args, **kwargs: True
 def maybe_show_banner():
     ctx = cli.cli.make_context(info_name=None, args=sys.argv)
     args = cli.cli.parse_args(ctx, args=sys.argv)
-    if args[0] == "run":
+    if not args:
+        cli.cli.parse_args(ctx, args=["kent-server", "--help"])
+
+    elif args[0] == "run":
         cmd = cli.cli.get_command(ctx, name="run")
         parser = cmd.make_parser(ctx)
         opts, _, _ = parser.parse_args(args[1:])


### PR DESCRIPTION
This fixes how Kent handles csp reports so that the Event is more correct and so we can rely on event.summary for logging a summary of the event to the console.

This also adds a datestamp for csp reports. It doesn't come from the payload--it's generated when handling the report.

This additionally fixes HTTP view code to use event.summary rather than have redundant code to determine the summary.

Fixes #91 